### PR TITLE
Fix params of run-release-tests task

### DIFF
--- a/tasks/run-release-tests.yml
+++ b/tasks/run-release-tests.yml
@@ -11,7 +11,8 @@ params:
   BOSH_USERNAME:
   BOSH_PASSWORD:
   BOSH_TARGET:
-  DEPLOYMENT_NAME:
+  RELEASE_NAME:
+  BITS_SERVICE_PRIVATE_ENDPOINT_IP:
 
 run:
   path: ci-tasks/scripts/run-release-tests.sh


### PR DESCRIPTION
The list of environment variables provided in run-release-tests.yml file does not match what is actually used by the script, which made `fly execute`ing this task troublesome.

Here is a fix.