### PR TITLE
Increase the network speed for the director

### DIFF
--- a/1-click/generate-bosh-lite-in-sl-manifest.sh
+++ b/1-click/generate-bosh-lite-in-sl-manifest.sh
@@ -12,5 +12,6 @@ bosh interpolate ~/workspace/bosh-deployment/bosh.yml \
     -o ~/workspace/bosh-deployment/bosh-lite.yml \
     -o ~/workspace/bosh-deployment/bosh-lite-runc.yml \
     -o ~/workspace/bosh-deployment/jumpbox-user.yml \
-    -o ~/workspace/1-click-bosh-lite-pipeline/operations/add-etc-hosts-entry.yml
+    -o ~/workspace/1-click-bosh-lite-pipeline/operations/add-etc-hosts-entry.yml \
+    -o ~/workspace/1-click-bosh-lite-pipeline/operations/increase-max-speed.yml
 


### PR DESCRIPTION
This ops files is necessary for the use of smoke-test from inside the "1-click- pipeline". And has to be default for our manifest generation.
[#154842976]