### PR TITLE
Disable dependency on Openstack Swift

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -142,7 +142,8 @@ jobs:
     - get: bits-service
       passed:
         - run-bitsgo-unit-tests
-        - run-bitsgo-contract-integration-test-openstack
+        # TODO: uncomment once we have an Openstack Swift account again
+        # - run-bitsgo-contract-integration-test-openstack
         - run-bitsgo-contract-integration-test-cos
         - run-bitsgo-contract-integration-test-s3
         - run-bitsgo-contract-integration-test-azure
@@ -329,7 +330,8 @@ jobs:
         # - run-CATs-in-bitsgo-google-service-account-bosh-lite
         # - run-CATs-in-bitsgo-alibaba-bosh-lite
         - run-CATs-in-bitsgo-local-bosh-lite
-        - run-CATs-in-bitsgo-openstack-bosh-lite
+        # TODO: uncomment once we have an Openstack Swift account again
+        # - run-CATs-in-bitsgo-openstack-bosh-lite
         - run-CATs-in-bitsgo-webdav-bosh-lite
       trigger: true
     - { get: ci-tasks, resource: bits-service-ci, trigger: true }


### PR DESCRIPTION
IBM is turning off its Swift offering. We have no alternative for Openstack currently.

I've paused the jobs in the Bits-Service pipeline, so they won't fail once the offering is turned off. I've also updated the pipeline in Concourse already (I still have access to that).

This change is just to make it possible to still cut new release even when integ-tests and CATs do not run with Swift backend.